### PR TITLE
fix: resolve dbt docs compilation error and improve setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,7 @@
     "ghcr.io/eitsupi/devcontainer-features/duckdb-cli:1": {}
   },
 
-  "postCreateCommand": "uv sync",
+  "postCreateCommand": "uv sync && uv run dbt deps",
 
   "customizations": {
     "vscode": {

--- a/README.md
+++ b/README.md
@@ -36,11 +36,12 @@ Three feed types are available:
 
 ```bash
 # Clone the repo
-git clone https://github.com/YOUR_USERNAME/gtfsrt-sandbox.git
+git clone https://github.com/JarvusInnovations/gtfsrt-sandbox.git
 cd gtfsrt-sandbox
 
 # Install dependencies (requires uv: https://docs.astral.sh/uv/)
 uv sync
+uv run dbt deps
 
 # Run dbt to download and transform data
 uv run dbt run
@@ -215,6 +216,10 @@ duckdb workshop.duckdb
 | description_text | string | Alert details |
 | cause | int | Cause code |
 | effect | int | Effect code |
+
+## Need Help?
+
+See [docs/troubleshooting.md](docs/troubleshooting.md) for common issues and solutions.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ uv run dbt run
 duckdb workshop.duckdb -ui
 ```
 
+> **Note:** If you get a "Failed to download extension" error with `-ui`, see [DuckDB UI Extension Error](docs/troubleshooting.md#duckdb-ui-extension-error).
+
 ## Choosing a Feed
 
 Available feeds are listed in `seeds/available_feeds.csv`. To use a different feed:

--- a/README.md
+++ b/README.md
@@ -34,12 +34,17 @@ Three feed types are available:
 
 ### Option 2: Local Setup
 
+**Prerequisites:**
+
+- [uv](https://docs.astral.sh/uv/getting-started/installation/) - Python package manager
+- [DuckDB CLI](https://duckdb.org/docs/installation/) - for interactive queries
+
 ```bash
 # Clone the repo
 git clone https://github.com/JarvusInnovations/gtfsrt-sandbox.git
 cd gtfsrt-sandbox
 
-# Install dependencies (requires uv: https://docs.astral.sh/uv/)
+# Install Python dependencies
 uv sync
 uv run dbt deps
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -7,6 +7,7 @@ profile: 'gtfsrt_sandbox'
 model-paths: ["models"]
 seed-paths: ["seeds"]
 macro-paths: ["macros"]
+docs-paths: ["docs"]
 target-path: "target"
 clean-targets:
   - "target"

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,67 @@
+# Troubleshooting
+
+## Network / Connection Issues
+
+**Symptom:** Queries hang or fail with connection errors
+
+DuckDB needs to download parquet files from Google Cloud Storage. If you're behind a firewall or have network issues:
+
+1. Check your internet connection
+2. Try the offline prefetch option:
+
+   ```bash
+   uv run python scripts/prefetch_data.py \
+       --feed-type vehicle_positions \
+       --feed-base64 aHR0cHM6Ly93d3czLnNlcHRhLm9yZy9ndGZzcnQvc2VwdGEtcGEtdXMvVmVoaWNsZS9ydFZlaGljbGVQb3NpdGlvbi5wYg \
+       --start-date 2026-01-04 \
+       --end-date 2026-01-04
+   ```
+
+## No Data Found
+
+**Symptom:** Queries return empty results
+
+The `start_date` and `end_date` in `dbt_project.yml` must match dates that have data available. To check available dates:
+
+```bash
+duckdb -c "
+SELECT DISTINCT date
+FROM read_parquet(
+    'gs://parquet.gtfsrt.io/vehicle_positions/date=*/base64url=aHR0cHM6Ly93d3czLnNlcHRhLm9yZy9ndGZzcnQvc2VwdGEtcGEtdXMvVmVoaWNsZS9ydFZlaGljbGVQb3NpdGlvbi5wYg/data.parquet',
+    hive_partitioning=true
+)
+ORDER BY date DESC
+LIMIT 10;
+"
+```
+
+Then update `dbt_project.yml` with valid dates.
+
+## dbt Compilation Errors
+
+**Symptom:** `dbt run` fails with compilation errors
+
+Try these steps:
+
+1. Clean and rebuild:
+
+   ```bash
+   uv run dbt clean
+   uv run dbt run
+   ```
+
+2. Check you're in the right directory (should contain `dbt_project.yml`)
+
+3. Ensure dependencies are installed:
+
+   ```bash
+   uv sync
+   ```
+
+## Getting Help
+
+If you're still stuck, [open an issue](https://github.com/JarvusInnovations/gtfsrt-sandbox/issues) with:
+
+- The full error message
+- Your environment (Codespaces, local macOS/Linux/Windows)
+- Steps to reproduce

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -59,6 +59,30 @@ Try these steps:
    uv sync
    ```
 
+## DuckDB UI Extension Error
+
+**Symptom:** `duckdb -ui` fails with "Failed to download extension" error
+
+```
+Extension Autoloading Error:
+Failed to download extension "ui" at URL "http://extensions.duckdb.org/..." (HTTP 404)
+```
+
+This is a [known issue](https://github.com/duckdb/duckdb/issues/19019) with DuckDB's UI extension. To fix it, install from the nightly build:
+
+```bash
+# Start DuckDB REPL
+duckdb
+
+# Install UI extension from nightly
+INSTALL ui FROM core_nightly;
+
+# Exit
+.quit
+```
+
+Now `duckdb workshop.duckdb -ui` should work.
+
 ## Getting Help
 
 If you're still stuck, [open an issue](https://github.com/JarvusInnovations/gtfsrt-sandbox/issues) with:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -47,6 +47,7 @@ Try these steps:
 
    ```bash
    uv run dbt clean
+   uv run dbt deps
    uv run dbt run
    ```
 

--- a/scripts/prefetch_data.py
+++ b/scripts/prefetch_data.py
@@ -94,6 +94,8 @@ def download_feed_data(
 
 
 def main():
+    global LOCAL_DATA_DIR
+
     parser = argparse.ArgumentParser(
         description="Pre-download GTFS-RT parquet data for offline use",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -155,7 +157,6 @@ Examples:
     else:
         feed_base64 = args.feed_base64
 
-    global LOCAL_DATA_DIR
     LOCAL_DATA_DIR = args.output_dir
 
     print(f"\nDownloading {args.feed_type} data:")


### PR DESCRIPTION
Fixes the dbt compilation error that prevented users from running `uv run dbt run` in Codespaces. The root cause was a missing `docs-paths` configuration in dbt_project.yml.

Also improves the setup experience by installing dbt dependencies automatically in Codespaces and documenting the step for local users. Adds a troubleshooting guide for common issues.