### PR TITLE
ci: add GitHub Actions workflow for dbt validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,72 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  DBT_PROFILES_DIR: ${{ github.workspace }}
+
+jobs:
+  validate:
+    name: Validate dbt project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Install Python dependencies
+        run: uv sync
+
+      - name: Install dbt dependencies
+        run: uv run dbt deps
+
+      - name: Parse dbt project
+        run: uv run dbt parse
+
+      - name: Compile dbt project
+        run: uv run dbt compile
+
+  test-pipeline:
+    name: Test full pipeline
+    runs-on: ubuntu-latest
+    needs: validate
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Install Python dependencies
+        run: uv sync
+
+      - name: Install dbt dependencies
+        run: uv run dbt deps
+
+      - name: Load seed data
+        run: uv run dbt seed
+
+      - name: Run dbt models
+        run: uv run dbt run
+
+      - name: Run dbt tests
+        run: uv run dbt test
+
+      - name: Generate dbt docs
+        run: uv run dbt docs generate
+
+      - name: Verify database was created
+        run: |
+          if [ ! -f workshop.duckdb ]; then
+            echo "Error: workshop.duckdb was not created"
+            exit 1
+          fi
+          echo "workshop.duckdb exists ($(stat -c%s workshop.duckdb) bytes)"


### PR DESCRIPTION
## Summary

- Add CI workflow that runs on every PR and push to main
- Prevent breaking the critical path documented in the README
- Catch issues like those fixed in #8 before they reach main

## CI Jobs

### 1. `validate` - Quick syntax/config validation (~30s)
- `uv sync` - Install Python dependencies
- `uv run dbt deps` - Install dbt packages
- `uv run dbt parse` - Validate SQL/Jinja syntax
- `uv run dbt compile` - Generate runtime SQL

### 2. `test-pipeline` - Full pipeline test (~2-3min)
- `uv run dbt seed` - Load seed data
- `uv run dbt run` - Run all models (downloads from GCS)
- `uv run dbt test` - Run model tests
- `uv run dbt docs generate` - Generate docs (validates fix from #8)
- Verify `workshop.duckdb` was created

## Test plan

- [ ] CI workflow runs on this PR
- [ ] Both jobs pass successfully
- [ ] The workflow catches common issues (can be verified by temporarily breaking something)

🤖 Generated with [Claude Code](https://claude.com/claude-code)